### PR TITLE
Adjust some styles for Redmine 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,17 @@ NOTE: Following samples are using 'Patrick Hand', 'Anzu' (as Japanese font).
 
 <img src='images/screenshot-messages.png' width='400'>
 
+## Supported Redmine versions
+
+6.0 or later
+
+NOTE: If you want to use this theme with Redmine 5.1 or earlier, please use 1.0.1 or earlier versions.
+
 ## Installation
 
 - Download zip file from release page
-- Extract zip file, and move to public/themes/redmine_theme_kodomo_midori at Redmine directory
+- Extract zip file, and move to themes/redmine_theme_kodomo_midori at Redmine directory
+- Restart Redmine
 - Open Redmine page, and go to Administration > Settings > Display
 - Enable the redmine_theme_kodomo_midori from Theme, and save settings
 
@@ -229,17 +236,15 @@ font
 
 #### テーマのみの配置
 
-- Redmineのディレクトリ/public/themes/ 以下に展開します
+- Redmineのディレクトリ/themes/ 以下に展開します
 - 配置後にRedmineを再起動します
 
-参考: Redmineのディレクトリ/public/themes/ 以下
+参考: Redmineのディレクトリ/themes/ 以下
 
 ```bash
 $ tree -L 1
 .
 ├── README
-├── alternate
-├── classic
 └── redmine_theme_kodomo_midori
 
 3 directories, 1 file

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -325,7 +325,7 @@ body.controller-issues.action-show div#content {
   color: #420707;
   outline: 2px dashed #fff;
   outline-offset: -5px;
-  padding: 10px 6px 0px 12px;
+  padding: 10px 6px 10px 12px;
 }
 
 #top-menu a {

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -1644,3 +1644,9 @@ a.icon-list_calendar.material-icons:hover {
   text-decoration: none;
 }
 /*---- calendar tooltip ----*/
+
+/*---- Attachment field ----*/
+.attachments_fields .filename {
+  padding-left: 20px;
+}
+/*---- Attachment field ----*/


### PR DESCRIPTION
This pull request fixes and adjusts some styles for Redmine 6.

### Fix overlapping display of attachment icons and file names

Before:
<img width="1138" alt="attachment-icon-before" src="https://github.com/user-attachments/assets/25f22f4a-2b31-4d66-8702-d8c93cef8bb5" />

After:
<img width="1138" alt="attachment-icon-after" src="https://github.com/user-attachments/assets/3bba5217-2b96-4b6d-9d6e-ea217a38e64e" />

### Adjust bottom padding in the top menu:

Before:
<img width="1138" alt="menu-item-before" src="https://github.com/user-attachments/assets/4514681d-1a25-437e-8ba6-1822df48ecd4" />

After:
<img width="1138" alt="menu-item-after" src="https://github.com/user-attachments/assets/bf151fa2-ca2c-4e02-8683-f049d5da8ae2" />

### 