### PR TITLE
Adjust admin-menu style for Redmine 6

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -518,6 +518,10 @@ div#admin-index>#admin-menu li {
   position: relative;
 }
 
+div#admin-index>#admin-menu a {
+  padding-left: 20px;
+}
+
 div#admin-index>#admin-menu a.selected {
   background-color: transparent;
   color: #820505;
@@ -525,6 +529,10 @@ div#admin-index>#admin-menu a.selected {
 
 div#admin-index>#admin-menu li a[class*="icon-"] {
   background-image: none;
+}
+
+div#admin-index>#admin-menu li svg {
+  display: none;
 }
 
 div#admin-index>#admin-menu li a.icon::before {

--- a/stylesheets/responsive.css
+++ b/stylesheets/responsive.css
@@ -88,6 +88,10 @@
     font-size: 16px;
   }
 
+  .flyout-menu #admin-menu a svg {
+    stroke: #643503;
+  }
+
   .flyout-menu ul li a:hover {
     background-color: rgb(255, 255, 185);
     color: #4caf50;


### PR DESCRIPTION
This pull request will change the admin menu layout to match Redmine6

## Change 1: Fix overlapping icons in the Redmine 6 admin menu  

The SVG icons in Redmine 6 will be hidden, just like in Redmine 5, and padding will be adjusted accordingly.

| Current Theme + Redmine 5 Admin Menu | Current Theme + Redmine 6 Admin Menu | Updated Theme + Redmine 6 Admin Menu |
| --- | --- | --- |
| <img width="874" alt="screenshot 2025-03-03 14 22 25" src="https://github.com/user-attachments/assets/194eafde-bdc6-4e59-b12f-964234e83309" /> | <img width="874" alt="screenshot 2025-03-03 14 21 55" src="https://github.com/user-attachments/assets/fec5a5f9-52be-49ab-978e-81fab76afcb0" /> | <img width="956" alt="screenshot 2025-03-03 14 42 39" src="https://github.com/user-attachments/assets/508f1fa4-41bc-4467-a219-1792d542a797" /> |

## Change 2: Adjust icon color in the admin menu inside the hamburger menu on narrow screens  

The icon color in the admin menu inside the hamburger menu will be changed to match the text color.

| Before | After |
| --- | --- |
| <img width="828" alt="screenshot 2025-03-03 14 44 09" src="https://github.com/user-attachments/assets/a769f7b5-91d0-4150-b78e-88509f757157" /> | <img width="887" alt="screenshot 2025-03-03 14 34 29" src="https://github.com/user-attachments/assets/6378f0f5-4740-4193-8507-b70d21438691" /> |
