### PR TITLE
Improve journal layout

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -1229,7 +1229,7 @@ a.journal-link {
   display: inline-block;
   position: relative;
   top: -10px;
-  right: 10px;
+  right: 5px;
   margin: 0;
   padding: 4px 0;
   z-index: 2;

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -1298,6 +1298,11 @@ div.journal h4 img.gravatar {
   margin-left: -24px;
 }
 
+div.journal .note-header {
+  min-height: 26px;
+  box-sizing: content-box;
+}
+
 div#activity dl {
   border-left: 2px dotted rgb(184, 207, 206);
   padding-left: 9px;


### PR DESCRIPTION
This pull request includes two improvements for better layout consistency:

1. [Set min-height for .note-header](https://github.com/redmica/redmine_theme_kodomo_midori/commit/cdcb2af62bec6c7046d41301e74ffe0b9138c8f0)
   - Prevents .note-header from having an excessively small height when the Gravatar icon is not present.
   - Ensures a more uniform appearance for notes, even when user avatars are missing.

2. [Adjust .journal-link positioning for better spacing](https://github.com/redmica/redmine_theme_kodomo_midori/commit/1ff9fb72a18e3d23a9e2a34939582b68b5ea75f9)
   - Increases the spacing around .journal-link to avoid overlapping with other links.
   - Improves readability and reduces the likelihood of accidental clicks.

|---|before|after|
|---|--|--|
|with Gravater|<img width="725" alt="screenshot 2025-05-16 11 57 14" src="https://github.com/user-attachments/assets/ed478ebd-77d1-4788-bce5-56e4cf597a63" />|<img width="725" alt="screenshot 2025-05-16 11 45 16" src="https://github.com/user-attachments/assets/2bea8023-d4bb-4b11-9463-98c6f4b26357" />|
|without Gravatar|<img width="725" alt="screenshot 2025-05-16 11 56 52" src="https://github.com/user-attachments/assets/cb1f1883-dbb0-4ed0-9f33-8269fd69addd" />|<img width="725" alt="screenshot 2025-05-16 11 45 25" src="https://github.com/user-attachments/assets/a8093b8e-845a-4884-bc75-bfc111bdfc23" />|