### PR TITLE
Disable pointer events for Great job ribbon

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -1201,6 +1201,7 @@ form#issue-form fieldset {
   overflow: hidden;
   right: 0px;
   bottom: 0px;
+  pointer-events: none;
 }
 
 .ribbon {


### PR DESCRIPTION
Add a `pointer-events: none;` style definition to this element to solve the problem of not being able to click on the link under the Great job ribbon.
<img width="338" alt="screenshot 2025-05-16 13 39 49" src="https://github.com/user-attachments/assets/83850c70-822e-4fe4-be0f-d0e73d1023a9" />
