### PR TITLE
Fix list items layout

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -1075,7 +1075,6 @@ a[class*="icon-"]:hover {
 
 #content .contextual .drdn-items a {
   display: block;
-  width: 100%;
 }
 
 /*----- context menu ------*/

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -1073,6 +1073,11 @@ a[class*="icon-"]:hover {
   background-position-x: 4px;
 }
 
+#content .contextual .drdn-items a {
+  display: block;
+  width: 100%;
+}
+
 /*----- context menu ------*/
 .issue.context-menu-selection {
   background-color: #2e7480 !important;

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -527,6 +527,17 @@ div#admin-index>#admin-menu a.selected {
   color: #820505;
 }
 
+#sidebar #admin-menu li {
+  padding: 0 1em 0 2.3em;
+}
+#sidebar #admin-menu a {
+  display: block;
+  width: 100%;
+}
+#sidebar #admin-menu a.selected svg.icon-svg {
+  stroke: #820505 !important;
+}
+
 div#admin-index>#admin-menu li a[class*="icon-"] {
   background-image: none;
 }

--- a/stylesheets/responsive.css
+++ b/stylesheets/responsive.css
@@ -77,6 +77,7 @@
     line-height: 40px;
     display: block;
     overflow: hidden;
+    width: 100%;
     height: 40px;
     white-space: nowrap;
     text-overflow: ellipsis;


### PR DESCRIPTION
This pull request fixes the issue where the clickable area of a tags in several menus and dropdowns was not covering 100% of the intended area, making the links difficult to click.

### [Admin menu styling updates:](https://github.com/redmica/redmine_theme_kodomo_midori/commit/b4ba9f9aec747410fd9dd60dc600c037ebcc00ab)
* Ensured admin menu links (`#sidebar #admin-menu a`) are displayed as block elements and take up the full width of their container.
* Updated the stroke color for selected admin menu icons to match the selected text color (`#sidebar #admin-menu a.selected svg.icon-svg`).

before:
<img width="738" alt="screenshot 2025-05-16 16 41 22" src="https://github.com/user-attachments/assets/6edde10f-635f-4618-bae9-b163d1619734" />

### [issue's dropdown menu styling updates:](https://github.com/redmica/redmine_theme_kodomo_midori/commit/c8d428db7a25b254d5c3708106446f46f83cf5ba)
* Ensured links in contextual dropdown menus (`#content .contextual .drdn-items a`) are displayed as block elements and span the full width for better usability.

before:
<img width="234" alt="screenshot 2025-05-16 16 35 18" src="https://github.com/user-attachments/assets/885eb2a9-ba8b-4b3e-b6b8-f443c8d58ce7" />


### [Setting page's flyout-menu styling updates:](https://github.com/redmica/redmine_theme_kodomo_midori/commit/31281193acbf5c5ecfa8a8cbe3638cf1da894141)
* Added a `width: 100%` property to ensure elements in responsive layouts take up the full width of their container.

before:
<img width="463" alt="screenshot 2025-05-16 16 39 06" src="https://github.com/user-attachments/assets/ff17b8f0-7d9b-41c8-b823-ddab0609b620" />