### PR TITLE
Fix extra padding in code block copy button and unnecessary hover background color

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -448,10 +448,6 @@ div.box p > label::before {
   font-size: 18px;
 }
 
-#content .tabs ul li:hover {
-  background-color: #ffffe2;
-}
-
 #content .tabs ul li a {
   border: 1px solid #ccc;
   border-bottom: 1px solid #bbbbbb;

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -1678,3 +1678,15 @@ a.icon-list_calendar.material-icons:hover {
   padding-left: 20px;
 }
 /*---- Attachment field ----*/
+
+/*---- Button to copy pre content ---*/
+div.wiki .copy-pre-content-link {
+  line-height: normal;
+  font-size: 0.875rem;
+  margin-right: 4px;
+}
+div#message_topic_wiki .copy-pre-content-link {
+  margin-right: 6px;
+}
+
+/*---- Button to copy pre content ---*/


### PR DESCRIPTION
This pull request includes the following fixes:

* Removes extra padding from the copy button in code blocks in issue descriptions
* Prevents an unwanted background color from appearing when hovering over command buttons in the wiki

## Removes unnecessary padding from the copy button in code blocks in issue descriptions

| Before fix | After fix |
| --- | --- |
| ![CleanShot 2025-06-03 at 15 44 39](https://github.com/user-attachments/assets/99665e6d-b067-431e-a07c-a88973b3f8cd) | ![CleanShot 2025-06-03 at 15 44 19](https://github.com/user-attachments/assets/25a2572a-36aa-4abb-b9ad-aec63b39475d) |

## Prevents an unwanted background color when hovering over command buttons in the wiki

| Before fix | After fix |
| --- | --- |
| ![CleanShot 2025-06-03 at 15 43 23](https://github.com/user-attachments/assets/cd4e4a24-fe2d-4a10-a3c4-b066e83f3bcf) | ![CleanShot 2025-06-03 at 15 43 48](https://github.com/user-attachments/assets/99663db5-53a7-468b-8681-bfef06975143) |
