### PR TITLE
Support Redmine 6.1

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -839,7 +839,7 @@ div.issue .subject h3 {
 
 /*--- news ---*/
 article.news-article {
-  paddinf-left: 20px;
+  padding-left: 20px;
 }
 
 article.news-article div.wiki {

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -934,28 +934,26 @@ body.controller-news.action-show div#content>div.wiki::before {
   transform: rotate(12deg);
 }
 
-div#comments>div.wiki {
+div#comments .journal div.wiki {
   border-bottom: 1px dashed rgb(183, 182, 181);
   margin-bottom: 10px;
   padding: 8px;
 }
 
-div#comments>h4:nth-of-type(odd) {
+div#comments .journal:nth-of-type(odd) {
   margin-right: 30px;
 }
 
-div#comments>h4:nth-of-type(odd)+div.wiki {
+div#comments .journal:nth-of-type(odd) div.wiki {
   background-color: #f3f7d9;
-  margin-right: 30px;
 }
 
-div#comments>h4:nth-of-type(even) {
+div#comments .journal:nth-of-type(even) {
   margin-left: 30px;
 }
 
-div#comments>h4:nth-of-type(even)+div.wiki {
+div#comments .journal:nth-of-type(even) div.wiki {
   background-color: #fdfbfb;
-  margin-left: 30px;
 }
 
 /*-- show messages --*/
@@ -964,7 +962,7 @@ body.controller-messages.action-show div#content {
   padding-left: 20px;
 }
 
-div#content>div.message>div.wiki {
+div#message_topic_wiki{
   font-size: 1.1em;
   position: relative;
   padding-left: 10px;
@@ -977,28 +975,28 @@ div#content>div.message>div.wiki {
   box-shadow: 4px 4px 4px #55555578, 2px 2px 2px 2px rgba(0, 0, 0, 0.3) inset;
 }
 
-div#content>div.message>div.wiki::before,
-div#content>div.message>div.wiki::after {
+div#message_topic_wiki::before,
+div#message_topic_wiki::after {
   position: absolute;
   content: "";
   bottom: 0;
 }
 
-div#content>div.message>div.wiki::before {
+div#message_topic_wiki::before {
   width: 20px;
   right: 10px;
   border: solid 3px #ffff00;
   border-radius: 3px 2px 0 2px;
 }
 
-div#content>div.message>div.wiki::after {
+div#message_topic_wiki::after {
   width: 15px;
   right: 45px;
   border: solid 3px #fff;
   border-radius: 8px 5px 2px 5px;
 }
 
-div#content>div.message>div.wiki pre {
+div#message_topic_wiki pre {
   color: initial;
 }
 
@@ -1012,11 +1010,11 @@ div#replies div.wiki p {
   margin: 2px;
 }
 
-div#replies>div:nth-of-type(odd) {
+div#replies .journal:nth-of-type(odd) {
   margin-right: 30px;
 }
 
-div#replies>div:nth-of-type(even) {
+div#replies .journal:nth-of-type(even) {
   margin-left: 30px;
   margin-right: 30px;
 }
@@ -1236,7 +1234,7 @@ form#issue-form fieldset {
   border-bottom: dashed 2px rgba(255, 255, 255, 0.65);
 }
 
-a.journal-link {
+.journals .journal .journal-meta .journal-link {
   display: inline-block;
   position: relative;
   top: -10px;
@@ -1251,7 +1249,7 @@ a.journal-link {
   background: #bad655;
 }
 
-a.journal-link:after {
+.journals .journal .journal-meta .journal-link:after {
   content: "";
   position: absolute;
   left: 0;
@@ -1296,7 +1294,17 @@ img.gravatar {
   margin: 2px;
 }
 
-img.gravatar:hover {
+span[role="img"].avatar {
+  border-radius: 50%;
+  box-shadow: 1px 0px 1px #e8e4d7;
+  border: 5px solid transparent;
+  background-clip: padding-box;
+  margin-right: 2px;
+  /* Prevent the badge from shrinking when box-sizing: border-box is applied on small viewports */
+  box-sizing: content-box;
+}
+
+img.gravatar:hover, span[role="img"].avatar:hover {
   -moz-transform: scale(1.4, 1.4);
   -webkit-transform: scale(1.4, 1.4);
   -o-transform: scale(1.4, 1.4);
@@ -1305,13 +1313,26 @@ img.gravatar:hover {
   transition : all 0.5s ease 0s;
 }
 
-div.journal h4 img.gravatar {
-  margin-left: -24px;
+.journals .journal {
+  padding-left: 32px;
 }
 
-div.journal .note-header {
+.journals .journal .journal-header img.gravatar,
+.journals .journal .journal-header span[role="img"].avatar {
+  margin-left: -30px;
+}
+.journals .journal .journal-header span[role="img"].avatar {
+  margin-bottom: -2px;
+}
+
+.journals .journal .journal-header {
   min-height: 26px;
   box-sizing: content-box;
+  background-color: transparent;
+  border-bottom: 1px solid #ccc;
+
+  padding-bottom: 0;
+  padding-top: 0;
 }
 
 div#activity dl {


### PR DESCRIPTION
## Overview

This PR addresses the following changes in Redmine 6.1:

* redmine-40744 Refresh history tabs look and feel
* redmine-29824 Add user initials when Gravatar is disabled

I’ve confirmed that these changes display correctly in Safari, Firefox, and Chrome.

## Screenshots

### Issue detail

Gravatar Off:
<img width="1137" height="1113" alt="CleanShot 2025-10-09 at 18 36 23" src="https://github.com/user-attachments/assets/bdda6e9e-9f82-40d3-b4b2-3140e4438e7a" />

Gravatar On (Initials):
<img width="1137" height="1113" alt="CleanShot 2025-10-09 at 18 36 12" src="https://github.com/user-attachments/assets/c6ba2155-1da7-47b4-8469-24a06614a5b6" />

### News

Gravatar Off:
<img width="1137" height="588" alt="CleanShot 2025-10-09 at 18 35 38" src="https://github.com/user-attachments/assets/f6b3f79c-de9f-4874-b86b-1fc3d6c304c2" />

Gravatar On (Initials):
<img width="1137" height="588" alt="CleanShot 2025-10-09 at 18 35 50" src="https://github.com/user-attachments/assets/8cc7b0e5-0547-4a59-b585-3cdd600cfabc" />

### Forum

Gravatar Off:
<img width="1137" height="588" alt="CleanShot 2025-10-09 at 18 35 29" src="https://github.com/user-attachments/assets/e6346228-06ac-46cc-9b49-0f0847ae5fdb" />

Gravatar On (Initials):
<img width="1137" height="588" alt="CleanShot 2025-10-09 at 18 35 07" src="https://github.com/user-attachments/assets/d12ad454-a118-4969-9a87-a4dc0e30e77e" />



