### PR TITLE
Override the background color of .badge-count with the previous color

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -709,6 +709,10 @@ table.list th,
   background-color: #d1edbc;
 }
 
+table.list .badge-count {
+  background-color: #9db9d5;
+}
+
 #content>div.splitcontent {
   font-size: 16px;
 }


### PR DESCRIPTION
Redmine core has introduced [Feature #43256 "Introduce Open Color to unify and standardize CSS colors"](https://www.redmine.org/issues/43256), which migrates the color system to Open Color.
As a result, UI elements no longer match the overall tone of the Bleuclair theme.
This pull request overrides a color value to maintain visual consistency with the original theme.

##  Changes

I’ve overridden the background color of the count badge displayed when Group by is set on the issue list.

|Before change| After change|
|---|---|
|<img width="804" height="432" alt="screenshot 2025-11-10 15 21 18" src="https://github.com/user-attachments/assets/9e2bf1d5-ded2-4a51-baac-1172194db870" />| <img width="804" height="432" alt="screenshot 2025-11-10 15 20 51" src="https://github.com/user-attachments/assets/24229fee-74c3-4607-bbf0-d93ac4c5cfd2" />|

## Note

The progress bar colors on the roadmap are affected by Redmine’s core color changes. However, since they blend well with the surrounding colors and don’t appear inconsistent, I decided not to modify them in this PR.
<img width="1045" height="291" alt="screenshot 2025-11-10 14 48 53" src="https://github.com/user-attachments/assets/c5f132d4-a5f5-4700-bcda-60e7d84dc2a8" />


Please let me know if there are any other areas that should be updated.