### PR TITLE
Adjust kodomo_midori header/main-menu overrides for Redmine issue 43937

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -344,7 +344,7 @@ body.controller-issues.action-show div#content {
   color: #066b59;
 }
 
-#loggedas a.user {
+#top-menu #loggedas a {
   color: #caff95;
 }
 
@@ -1642,3 +1642,49 @@ div#message_topic_wiki .copy-pre-content-link {
 }
 
 /*---- Button to copy pre content ---*/
+
+/* Added to maintain the original layout after header redesign in Redmine core (#43937) */
+
+#main-menu {
+  background: transparent;
+  padding: 0;
+  margin-left: 15px;
+}
+
+#main-menu li a.new-object {
+  padding-block: 5px;
+  padding-inline: 24px 11px;
+  border: none;
+}
+
+#main-menu ul.menu-children li a {
+  padding-block: 4px;
+  padding-inline: 24px 10px;
+}
+
+#main-menu li a.selected, #main-menu li a.selected:hover {
+  box-shadow: none;
+}
+
+#main-menu .tabs-buttons {
+  inset-inline-end: -3px;
+  inset-block-start: auto;
+  inset-block-end: 0;
+  transform: none;
+}
+
+#top-menu {
+  font-size: 0.8em;
+}
+
+#top-menu li {
+  margin-inline-end: 0px;
+}
+
+body #header {
+  padding-block-end: 20px;
+}
+
+#header h1 {
+  display: block;
+}

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -310,10 +310,15 @@ body.controller-issues.action-show div#content {
   border-right: none;
 }
 
+body #header {
+  padding-block-end: 20px;
+}
+
 #header h1 {
   text-align: 60px;
   line-height: 80px;
   font-size: 28pt;
+  display: block;
 }
 
 #header a {
@@ -326,6 +331,11 @@ body.controller-issues.action-show div#content {
   outline: 2px dashed #fff;
   outline-offset: -5px;
   padding: 10px 6px 10px 12px;
+  font-size: 0.8em;
+}
+
+#top-menu li {
+  margin-inline-end: 0px;
 }
 
 #top-menu a {
@@ -604,6 +614,12 @@ div#admin-index>#admin-menu li:hover {
   -o-transform: rotate(20deg);
 }
 
+#main-menu {
+  background: transparent;
+  padding: 0;
+  margin-left: 15px;
+}
+
 #main-menu li {
   margin: 0px 4px 0px 0px;
 }
@@ -648,11 +664,13 @@ div#admin-index>#admin-menu li:hover {
 #main-menu li a.selected:hover {
   background: rgb(246, 252, 205);
   color: rgb(58, 49, 2);
+  box-shadow: none;
 }
 
 #main-menu li a.selected {
   background-color: rgb(86, 199, 165);
   color: #ffffff;
+  box-shadow: none;
 }
 
 #main-menu li a.selected::before {
@@ -661,6 +679,9 @@ div#admin-index>#admin-menu li:hover {
 
 #main-menu li a.new-object {
   background-color: rgb(246, 255, 206);
+  padding-block: 5px;
+  padding-inline: 24px 11px;
+  border: none;
 }
 
 #main-menu .menu-children li a:hover {
@@ -668,10 +689,22 @@ div#admin-index>#admin-menu li:hover {
   background-color: rgb(246, 255, 206);
 }
 
+#main-menu ul.menu-children li a {
+  padding-block: 4px;
+  padding-inline: 24px 10px;
+}
+
 #main-menu .menu-children {
   border-right: 1px solid #c6ad35;
   border-bottom: 1px solid #c6ad35;
   border-left: 1px solid #c6ad35;
+}
+
+#main-menu .tabs-buttons {
+  inset-inline-end: -3px;
+  inset-block-start: auto;
+  inset-block-end: 0;
+  transform: none;
 }
 
 table.list {
@@ -1642,49 +1675,3 @@ div#message_topic_wiki .copy-pre-content-link {
 }
 
 /*---- Button to copy pre content ---*/
-
-/* Added to maintain the original layout after header redesign in Redmine core (#43937) */
-
-#main-menu {
-  background: transparent;
-  padding: 0;
-  margin-left: 15px;
-}
-
-#main-menu li a.new-object {
-  padding-block: 5px;
-  padding-inline: 24px 11px;
-  border: none;
-}
-
-#main-menu ul.menu-children li a {
-  padding-block: 4px;
-  padding-inline: 24px 10px;
-}
-
-#main-menu li a.selected, #main-menu li a.selected:hover {
-  box-shadow: none;
-}
-
-#main-menu .tabs-buttons {
-  inset-inline-end: -3px;
-  inset-block-start: auto;
-  inset-block-end: 0;
-  transform: none;
-}
-
-#top-menu {
-  font-size: 0.8em;
-}
-
-#top-menu li {
-  margin-inline-end: 0px;
-}
-
-body #header {
-  padding-block-end: 20px;
-}
-
-#header h1 {
-  display: block;
-}


### PR DESCRIPTION
## Summary

Fix layout issues to align with the changes in Redmine core header (https://www.redmine.org/issues/43937).

## What Changed

- To preserve the display of the traditional header and main menu, override Styles added in https://www.redmine.org/issues/43937 (around `#main-menu`, `.tabs-buttons`, `#header`, and `#top-menu`)

## Screenshots

Redmine before issue #43937 + `kodomo_midori`
<img width="959" height="150" alt="screenshot 2026-04-22 10 22 41" src="https://github.com/user-attachments/assets/1c20e8ae-afd7-4f3b-a301-4545127ba5cf" />

Redmine after issue #43937 + `kodomo_midori` before changes (Broken)
<img width="959" height="150" alt="screenshot 2026-04-22 10 19 55" src="https://github.com/user-attachments/assets/b26ff0d7-f6c5-4d5d-a52b-9cc641ca4b52" />

Redmine after issue #43937 + `kodomo_midori` after changes (Fixed)
<img width="959" height="150" alt="screenshot 2026-04-22 10 19 41" src="https://github.com/user-attachments/assets/48d4d8ed-4699-43d6-b783-2120b037e371" />

Redmine after issue #43937 + `kodomo_midori` (Compatible)
<img width="959" height="150" alt="screenshot 2026-04-22 10 21 12" src="https://github.com/user-attachments/assets/6c01c867-2957-4456-96e4-38486205a9ac" />

## Note

I have confirmed that it is also compatible with Redmine 6.1-stable