### PR TITLE
Override style of selected sidebar link and its SVG icon stroke color

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -410,6 +410,10 @@ body #header {
   background: rgba(247, 206, 155, 0.3);
 }
 
+#sidebar a.selected,
+#sidebar a.selected:hover { background-color: #1864ab99; color: #fff; box-shadow: none; border-radius: 3px; }
+#sidebar a.selected svg.icon-svg { stroke: #fff !important; }
+
 .box {
   background-color: #fbfedb;
   color: #4c0a0a;


### PR DESCRIPTION
## Summary

Override the style of selected sidebar links to align with the changes introduced in Redmine issue #43988.

## What Changed

- Override #sidebar a.selected and #sidebar a.selected:hover to keep the existing blue background and white text style
- Override SVG icon stroke color of selected sidebar links to white so that icons remain visible against the blue background
  - Note that in the current Redmine codebase, sidebar icons only appear under #admin-menu. Those links are already overridden by the rule div#admin-index > #admin-menu a.selected, which sets color: #820505 in kodomo_midori, so this rule has no practical effect at the moment. It is added here as a forward-looking measure in case sidebar links with icons appear outside of the admin menu in the future.

## Screenshot

<img width="284" height="268" alt="screenshot 2026-05-01 15 22 11" src="https://github.com/user-attachments/assets/6b361217-8af2-484d-a923-096d2c925752" />


## Note

Redmine issue #43988 changed the default style of selected sidebar links to use an indigo color scheme. The alternate and classic themes added overrides in the same commit. This PR adds the equivalent override for the kodomo_midori theme.
https://github.com/redmine/redmine/blob/c8498681bda825c406a8d95d0f204e99e4e71c7d/app/assets/themes/alternate/stylesheets/application.css#L39-L41